### PR TITLE
changing the way the history-value print, / --> ÷, * --> ×

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,11 +23,11 @@
 				<button class="operator" id="clear">C</button>
 				<button class="operator" id="backspace">CE</button>
 				<button class="operator" id="%">%</button>
-				<button class="operator" id="/">&#247;</button>
+				<button class="operator" id="÷">&#247;</button>
 				<button class="number" id="7">7</button>
 				<button class="number" id="8">8</button>
 				<button class="number" id="9">9</button>
-				<button class="operator" id="*">&times;</button>
+				<button class="operator" id="×">&times;</button>
 				<button class="number" id="4">4</button>
 				<button class="number" id="5">5</button>
 				<button class="number" id="6">6</button>

--- a/script.js
+++ b/script.js
@@ -1,8 +1,8 @@
 function getHistory(){
-	return document.getElementById("history-value").innerText;
+	return document.getElementById("history-value").innerText.replace("÷","/").replace("×","*");
 }
 function printHistory(num){
-	document.getElementById("history-value").innerText=num;
+	document.getElementById("history-value").innerText = num;
 }
 function getOutput(){
 	return document.getElementById("output-value").innerText;
@@ -52,7 +52,7 @@ for(var i =0;i<operator.length;i++){
 				output= output==""?output:reverseNumberFormat(output);
 				history=history+output;
 				if(this.id=="="){
-					var result=eval(history);
+					var result= eval(history);
 					printOutput(result);
 					printHistory("");
 				}


### PR DESCRIPTION
Hey! in the printHistory function your program prints the operation with "*" and "/", I made a change that uses "*" instead of "×" and "/" instead of "÷", just to make it easier to read, and the math still works!